### PR TITLE
Added short link redirects

### DIFF
--- a/config/redirects.yml
+++ b/config/redirects.yml
@@ -1,0 +1,7 @@
+# This file does not control a specific page of the site, but it is used to add custom redirects or shortened links to the site.
+
+redirects:
+  - source: /drive # The shortened link, relative to chainlynx8248.com, this one redirects chainlynx8248.com/drive to the google drive folder below
+    destination: "https://drive.google.com/drive/u/7/folders/1lzuXskvDsEkPuN7AdGFsjqeD_FtDbEOK"
+  - source: /sponsorpacket
+    destination: "https://docs.google.com/document/d/1RlGrOoRH6tXi9jlLulZJgw9Zkisgg9WqSXQK1TN0fnQ/edit?usp=sharing"

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,20 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
 
-module.exports = nextConfig
+const fs = require("fs");
+const yaml = require("yaml");
+
+module.exports = {
+    async redirects() {
+
+        const configText = fs.readFileSync("./config/redirects.yml", "utf8");
+        const config = yaml.parse(configText);
+
+        return config.redirects.map((redirect) => {
+            return {
+                source: redirect.source,
+                destination: redirect.destination,
+                permanent: true,
+            }
+        });
+    }
+}


### PR DESCRIPTION
Using a new config file in `./config/redirects.yml`, we can add shorted links such as `chainlynx8248.com/drive` to redirect to our Google Drive link using just markdown formatting.